### PR TITLE
Remove unnecessary `unsafe` from Bucket

### DIFF
--- a/native/sorted_set_nif/src/bucket.rs
+++ b/native/sorted_set_nif/src/bucket.rs
@@ -25,25 +25,9 @@ impl Bucket {
     }
 
     pub fn split(&mut self) -> Bucket {
-        let curr_len = self.data.len();
-        let at = curr_len / 2;
-
-        let other_len = self.data.len() - at;
-        let mut other = Vec::with_capacity(curr_len);
-
-        // Unsafely `set_len` and copy items to `other`.
-        unsafe {
-            self.data.set_len(at);
-            other.set_len(other_len);
-
-            ptr::copy_nonoverlapping(
-                self.data.as_ptr().offset(at as isize),
-                other.as_mut_ptr(),
-                other.len(),
-            );
+        Bucket {
+            data: self.data.split_off( self.data.len() / 2 )
         }
-
-        Bucket { data: other }
     }
 
     pub fn item_compare(&self, item: &SupportedTerm) -> Ordering {


### PR DESCRIPTION
Hey 👋

It contained code identical to [Vec::split_off](https://doc.rust-lang.org/src/alloc/vec.rs.html#1375-1389). Is there a reason for not relying on the std method?