### PR TITLE
Document reason for Bucket::split existing

### DIFF
--- a/native/sorted_set_nif/src/bucket.rs
+++ b/native/sorted_set_nif/src/bucket.rs
@@ -25,6 +25,10 @@ impl Bucket {
     }
 
     pub fn split(&mut self) -> Bucket {
+        // This code is very similar to Vec::split_off
+        // The difference being that `other` has the
+        // same capacity as `curr_len` rather than
+        // having the capacity of `other_len`.
         let curr_len = self.data.len();
         let at = curr_len / 2;
 


### PR DESCRIPTION
Ref: #13 