### PR TITLE
fix 'view source' docs links

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule SortedSet.MixProject do
       name: "SortedSet",
       extras: ["README.md"],
       main: "readme",
-      source_url: "https://github.com/discord/sorted_set"
+      source_url: "https://github.com/discord/sorted_set_nif"
     ]
   end
 


### PR DESCRIPTION
These links are currently broken in the docs

![image](https://user-images.githubusercontent.com/34633373/164153745-ee3f8804-a844-45b3-9ed4-1762434a4ff8.png)

This fixes it 🦆 